### PR TITLE
CYRUS MAINA - feat: implement mock data provider with subject filters and types

### DIFF
--- a/bitcourse-frontend/.vite/deps/_metadata.json
+++ b/bitcourse-frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "fd6cdba1",
+  "configHash": "79caa67a",
+  "lockfileHash": "abc711d6",
+  "browserHash": "1ac91472",
+  "optimized": {},
+  "chunks": {}
+}

--- a/bitcourse-frontend/.vite/deps/package.json
+++ b/bitcourse-frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/bitcourse-frontend/src/App.css
+++ b/bitcourse-frontend/src/App.css
@@ -3,31 +3,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50 antialiased;
-    font-family: var(--font-sans);
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
-@import "tailwindcss";
-
-@custom-variant dark (&:is(.dark *));
-
 :root {
   --background: oklch(0.9383 0.0042 236.4993);
   --foreground: oklch(0.3211 0 0);
@@ -191,9 +166,415 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border outline-ring/50 antialiased;
+    font-family: var(--font-sans);
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer components {
+  .page-title {
+    @apply text-3xl font-bold text-foreground tracking-tight;
+  }
+
+  .column-title {
+    @apply flex items-center gap-1 font-bold;
+  }
+
+  .search-field {
+    @apply relative w-full max-h-9 md:max-w-72;
+
+    .search-icon {
+      @apply absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-primary;
+    }
+  }
+
+  .actions-row {
+    @apply flex flex-col gap-3 sm:flex-row sm:gap-2 w-full sm:w-auto;
+  }
+
+  .sign-up {
+    @apply flex flex-col items-center justify-center px-6 py-8 min-h-svh;
+
+    .logo {
+      @apply flex items-center justify-center;
+
+      img {
+        @apply h-12 w-12;
+      }
+    }
+
+    .card {
+      @apply w-full max-w-xl p-12 mt-6;
+    }
+
+    .header {
+      @apply px-0;
+    }
+
+    .title {
+      @apply text-3xl font-semibold;
+    }
+
+    .description {
+      @apply text-muted-foreground;
+    }
+
+    .content {
+      @apply px-0;
+    }
+
+    .form {
+      @apply space-y-6;
+
+      [data-slot="label"] {
+        @apply text-sm font-medium;
+      }
+
+      [data-slot="input"] {
+        @apply w-full;
+      }
+    }
+
+    .roles {
+      @apply grid w-full grid-cols-2 gap-3;
+
+      .role-button {
+        @apply flex flex-col items-center justify-center gap-2 rounded-md border border-input bg-background p-3 text-sm font-medium transition-colors;
+
+        &.is-active {
+          @apply border-primary bg-primary/10 text-primary;
+        }
+
+        svg {
+          @apply h-6 w-6;
+        }
+
+        span {
+          @apply text-sm;
+        }
+      }
+    }
+
+    .field {
+      @apply flex flex-col gap-3;
+    }
+
+    .submit {
+      @apply w-full mt-2;
+    }
+
+    .footer {
+      @apply w-full text-center text-sm px-0;
+
+      span {
+        @apply text-muted-foreground mr-2;
+      }
+
+      a {
+        @apply font-semibold underline;
+      }
+    }
+  }
+
+  .sign-in {
+    @apply flex flex-col items-center justify-center px-6 py-8 min-h-svh;
+
+    .logo {
+      @apply flex items-center justify-center;
+
+      img {
+        @apply h-12 w-12;
+      }
+    }
+
+    .card {
+      @apply w-full max-w-xl p-12 mt-6;
+    }
+
+    .header {
+      @apply px-0;
+    }
+
+    .title {
+      @apply text-3xl font-semibold;
+    }
+
+    .description {
+      @apply text-muted-foreground font-medium;
+    }
+
+    .content {
+      @apply px-0;
+    }
+
+    .form {
+      @apply space-y-6;
+
+      [data-slot="label"] {
+        @apply text-sm font-medium;
+      }
+
+      [data-slot="input"] {
+        @apply w-full;
+      }
+    }
+
+    .field {
+      @apply flex flex-col gap-2;
+    }
+
+    .row {
+      @apply flex items-center justify-between flex-wrap gap-2;
+    }
+
+    .remember {
+      @apply flex items-center space-x-2;
+    }
+
+    .forgot-link {
+      @apply text-sm flex items-center gap-2 text-primary hover:underline;
+
+      svg {
+        @apply h-4 w-4;
+      }
+    }
+
+    .submit {
+      @apply w-full mt-6;
+    }
+
+    .split {
+      @apply flex items-center gap-4 mt-6;
+
+      span {
+        @apply text-sm text-muted-foreground;
+      }
+
+      > :first-child,
+      > :last-child {
+        @apply flex-1;
+      }
+    }
+
+    .social {
+      @apply flex flex-col gap-4 mt-6;
+
+      p {
+        @apply text-sm font-medium;
+      }
+
+      .social-grid {
+        @apply grid grid-cols-2 gap-6;
+      }
+
+      .social-button {
+        @apply flex items-center gap-2;
+      }
+    }
+
+    .footer {
+      @apply w-full text-center text-sm space-x-1;
+
+      span {
+        @apply text-sm text-muted-foreground;
+      }
+
+      a {
+        @apply font-semibold underline;
+      }
+    }
+  }
+
+  .intro-row {
+    @apply flex flex-col gap-5 lg:flex-row justify-between space-y-4;
+  }
+
+  .class-view {
+    @apply container mx-auto pb-8 px-2 sm:px-4;
+  }
+
+  .class-form-card {
+    @apply max-w-3xl gap-2 w-full mx-auto relative overflow-hidden border shadow-sm border-foreground/20;
+  }
+
+  .upload-dropzone {
+    @apply flex flex-col items-center justify-center gap-4 min-h-40 border-2 border-dashed border-foreground/20 bg-primary/5 w-full mt-3 cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed rounded-md;
+
+    .upload-prompt {
+      @apply flex flex-col sm:flex-row items-center justify-center gap-4 p-5;
+
+      .icon {
+        @apply size-10 text-orange-600;
+      }
+
+      div {
+        @apply text-center sm:text-left;
+
+        :first-child {
+          @apply text-sm font-bold text-orange-600 mb-1;
+        }
+
+        :last-child {
+          @apply text-xs text-foreground/60;
+        }
+      }
+    }
+  }
+
+  .upload-preview {
+    @apply relative w-full;
+
+    img {
+      @apply size-full object-cover rounded-md;
+    }
+
+    button {
+      @apply absolute top-2 right-3 z-10 cursor-pointer;
+    }
+  }
+
+  .class-show {
+    .state-message {
+      @apply mt-6 text-sm text-muted-foreground;
+    }
+
+    .state-message.is-error {
+      @apply text-destructive;
+    }
+
+    .banner {
+      @apply mt-5 mb-1;
+
+      img {
+        @apply w-full aspect-5/1 rounded-xl object-cover shadow-md;
+      }
+
+      .placeholder {
+        @apply h-72 w-full bg-slate-200;
+      }
+    }
+
+    .details-card {
+      @apply p-6 sm:p-8 space-y-3 shadow-md;
+    }
+
+    .details-header {
+      @apply flex flex-col sm:flex-row sm:items-start justify-between gap-5 mb-4;
+
+      > div:first-child {
+        @apply flex-1 space-y-2;
+
+        h1 {
+          @apply text-xl sm:text-2xl font-bold;
+        }
+
+        p {
+          @apply text-sm text-muted-foreground;
+        }
+      }
+
+      > div:last-child {
+        @apply space-x-2;
+
+        > * {
+          @apply px-3 py-1;
+        }
+
+        [data-status="active"] {
+          @apply bg-green-600 text-white;
+        }
+
+        [data-status="inactive"] {
+          @apply bg-gray-600 text-white;
+        }
+      }
+    }
+
+    .details-grid {
+      @apply grid sm:grid-cols-2 mt-8 gap-10 text-sm;
+    }
+
+    .instructor {
+      @apply space-y-2;
+
+      > p {
+        @apply text-xs mb-3 font-bold text-gray-400 uppercase tracking-wider;
+      }
+
+      > div {
+        @apply space-y-2 flex items-center gap-2;
+      }
+
+      img {
+        @apply size-13 rounded-full object-cover;
+      }
+
+      > div > div > p:first-child {
+        @apply text-base font-mono font-bold text-primary;
+      }
+
+      > div > div > p:last-child {
+        @apply text-sm font-medium mb-2;
+      }
+    }
+
+    .department {
+      @apply space-y-2;
+
+      > p {
+        @apply text-xs font-bold text-muted-foreground uppercase tracking-wider;
+      }
+
+      > div {
+        @apply space-y-2;
+
+        p:first-child {
+          @apply text-lg font-bold text-primary;
+        }
+
+        p:last-child {
+          @apply text-sm text-muted-foreground line-clamp-1;
+        }
+      }
+    }
+
+    .subject {
+      @apply space-y-2;
+
+      > p {
+        @apply text-xs font-bold text-muted-foreground uppercase tracking-wider;
+      }
+
+      > div {
+        @apply space-y-2;
+
+        span {
+          @apply font-extrabold;
+        }
+
+        p:first-of-type {
+          @apply text-lg font-bold text-primary;
+        }
+
+        p:last-of-type {
+          @apply text-sm text-muted-foreground mt-2 leading-relaxed;
+        }
+      }
+    }
+
+    .join {
+      @apply space-y-2;
+
+      h2 {
+        @apply text-xs font-bold text-muted-foreground uppercase tracking-wider;
+      }
+
+      ol {
+        @apply text-sm text-muted-foreground space-y-1.5 list-decimal list-inside mt-2;
+      }
+    }
   }
 }

--- a/bitcourse-frontend/src/constants/index.ts
+++ b/bitcourse-frontend/src/constants/index.ts
@@ -1,0 +1,10 @@
+export const DEPARTMENTS = [
+    'Computer Science',
+    'Mathematics',
+    'English',
+]
+
+export const DEPARTMENT_OPTIONS = DEPARTMENTS.map((dept) => ({
+    value: dept,
+    label: dept,
+}))

--- a/bitcourse-frontend/src/constants/mock-data.ts
+++ b/bitcourse-frontend/src/constants/mock-data.ts
@@ -1,0 +1,28 @@
+import { Subject } from "../types";
+
+export const MOCK_SUBJECTS: Subject[] = [
+    {
+        id: 1,
+        code: "CS101",
+        name: "Introduction to Computer Science",
+        department: "CS",
+        description: "An introductory course covering the fundamentals of computer science.",
+        createdAt: new Date().toISOString(),
+    },
+    {
+        id: 2,
+        code: "MATH201",
+        name: "Calculus II",
+        department: "Math",
+        description: "Advanced study of integration techniques and series.",
+        createdAt: new Date().toISOString(),
+    },
+    {
+        id: 3,
+        code: "ENG102",
+        name: "Literature and Composition",
+        department: "English",
+        description: "A course focused on critical reading and writing skills.",
+        createdAt: new Date().toISOString(),
+    },
+]

--- a/bitcourse-frontend/src/pages/subjects/lists.tsx
+++ b/bitcourse-frontend/src/pages/subjects/lists.tsx
@@ -1,8 +1,119 @@
-import React from 'react'
+import React, {useMemo, useState} from 'react'
+import {ListView} from "@/components/refine-ui/views/list-view.tsx";
+import {Breadcrumb} from "@/components/refine-ui/layout/breadcrumb.tsx";
+import {Search} from "lucide-react";
+import {Badge} from "@/components/ui/badge.tsx";
+import {Input} from "@/components/ui/input.tsx";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select.tsx";
+import {DEPARTMENT_OPTIONS} from "@/constants";
+import {CreateButton} from "@/components/refine-ui/buttons/create.tsx";
+import {DataTable} from "@/components/refine-ui/data-table/data-table.tsx";
+import {useTable} from "@refinedev/react-table";
+import {Subject} from "@/types";
+import {ColumnDef} from "@tanstack/react-table";
 
 const SubjectsLists = () => {
+
+    const [searchQuery, setSearchQuery] = useState("");
+    const [selectedDepartment, setSelectedDepartment] = useState("");
+
+    const columns = useMemo<ColumnDef<Subject>[]>(() => [
+        {
+            id: 'code',
+            accessorKey: 'code',
+            size: 100,
+            header: () => <p className="column-title ml-2">Code</p>,
+            cell: ({ getValue }) => <Badge>{getValue<string>()}</Badge>
+        },
+        {
+            id: 'name',
+            accessorKey: 'name',
+            size: 200,
+            header: () => <p className="column-title">Name</p>,
+            cell: ({ getValue }) => <span className="text-foreground">{getValue<string>()}</span>,
+            filterFn: 'includesString'
+        },
+        {
+            id: 'department',
+            accessorKey: 'department',
+            size: 150,
+            header: () => <p className="column-title">Department</p>,
+            cell: ({ getValue }) => <Badge variant='secondary'>{getValue<string>()}</Badge>,
+            filterFn: 'includesString'
+        },
+        {
+            id: 'description',
+            accessorKey: 'description',
+            size: 300,
+            header: () => <p className="column-title">Description</p>,
+            cell: ({ getValue }) => <span className="truncate line-clamp-2">{getValue<string>()}</span>,
+            filterFn: 'includesString'
+        }
+    ], []);
+
+    const departmentFilters = selectedDepartment === 'all' ? [] : [
+        {field : 'department', operator: 'eq' as const, value: selectedDepartment},
+    ]
+    const searchFilters = searchQuery ? [
+        { field: 'name', operator: 'contains' as const, value: searchQuery }
+    ] : [];
+
+    const subjectTable = useTable<Subject>({
+        columns,
+        refineCoreProps: {
+            resource: 'subjects',
+            pagination: { pageSize: 10, mode: 'server' },
+            filters: {
+                permanent: [...departmentFilters, ...searchFilters]
+            },
+            sorters: {
+                initial: [
+                    {field: 'id', order: 'desc'}
+                ]
+            },
+        }
+    });
+
     return (
-        <div>SubjectsLists</div>
+        <ListView>
+            <Breadcrumb/>
+            <h1 className='page-title'>Subjects</h1>
+            <div className="intro-row">
+                <p>Quick access to essential metrics and management tools.</p>
+
+                <div className="actions-row">
+                    <div className="search-field">
+                        <Search className="search-icon" />
+                        <Input
+                            type="text"
+                            placeholder="Search by name ... "
+                            className="pl-10 w-full"
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                        />
+                    </div>
+
+                    <div>
+                        <Select value={selectedDepartment} onValueChange={setSelectedDepartment}>
+                            <SelectTrigger>
+                                <SelectValue placeholder='Filter by Department' />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value='all'>All Departments</SelectItem>
+                                {DEPARTMENT_OPTIONS.map(department => (
+                                    <SelectItem key={department.value} value={department.value}>
+                                        {department.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <CreateButton />
+                    </div>
+                </div>
+            </div>
+
+            <DataTable table={subjectTable} />
+        </ListView>
     )
 }
 export default SubjectsLists

--- a/bitcourse-frontend/src/providers/data.ts
+++ b/bitcourse-frontend/src/providers/data.ts
@@ -1,5 +1,20 @@
-import { createSimpleRestDataProvider } from "@refinedev/rest/simple-rest";
-import { API_URL } from "./constants";
-export const { dataProvider, kyInstance } = createSimpleRestDataProvider({
-  apiURL: API_URL,
-});
+import {BaseRecord, DataProvider, GetListParams, GetListResponse} from "@refinedev/core";
+import {MOCK_SUBJECTS} from "@/constants/mock-data.ts";
+
+export const dataProvider: DataProvider = {
+  getList: async <TData extends BaseRecord = BaseRecord>({ resource }:
+    GetListParams): Promise<GetListResponse<TData>> => {
+      if(resource !== 'subjects') return { data: [] as TData[], total: 0 };
+        return {
+          data: MOCK_SUBJECTS as unknown as TData[],
+          total: MOCK_SUBJECTS.length,
+        }
+  },
+
+  getOne: async () => {throw new Error('This function is not present in mock') },
+  create: async () => {throw new Error('This function is not present in mock') },
+  update: async () => {throw new Error('This function is not present in mock') },
+  deleteOne: async () => {throw new Error('This func is not present in mock') },
+
+  getApiUrl: () => '',
+}

--- a/bitcourse-frontend/src/types/index.ts
+++ b/bitcourse-frontend/src/types/index.ts
@@ -1,0 +1,122 @@
+export type Subject = {
+    id: number;
+    name: string;
+    code: string;
+    description: string;
+    department: string;
+    createdAt?: string;
+};
+
+export type ListResponse<T = unknown> = {
+    data?: T[];
+    pagination?: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+    };
+};
+
+export type CreateResponse<T = unknown> = {
+    data?: T;
+};
+
+export type GetOneResponse<T = unknown> = {
+    data?: T;
+};
+
+declare global {
+    interface CloudinaryUploadWidgetResults {
+        event: string;
+        info: {
+            secure_url: string;
+            public_id: string;
+            delete_token?: string;
+            resource_type: string;
+            original_filename: string;
+        };
+    }
+
+    interface CloudinaryWidget {
+        open: () => void;
+    }
+
+    interface Window {
+        cloudinary?: {
+            createUploadWidget: (
+                options: Record<string, unknown>,
+                callback: (
+                    error: unknown,
+                    result: CloudinaryUploadWidgetResults
+                ) => void
+            ) => CloudinaryWidget;
+        };
+    }
+}
+
+export interface UploadWidgetValue {
+    url: string;
+    publicId: string;
+}
+
+export interface UploadWidgetProps {
+    value?: UploadWidgetValue | null;
+    onChange?: (value: UploadWidgetValue | null) => void;
+    disabled?: boolean;
+}
+
+export enum UserRole {
+    STUDENT = "student",
+    TEACHER = "teacher",
+    ADMIN = "admin",
+}
+
+export type User = {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    email: string;
+    name: string;
+    role: UserRole;
+    image?: string;
+    imageCldPubId?: string;
+    department?: string;
+};
+
+export type Schedule = {
+    day: string;
+    startTime: string;
+    endTime: string;
+};
+
+export type Department = {
+    id: number;
+    name: string;
+    description: string;
+};
+
+export type ClassDetails = {
+    id: number;
+    name: string;
+    description: string;
+    status: "active" | "inactive";
+    capacity: number;
+    courseCode: string;
+    courseName: string;
+    bannerUrl?: string;
+    bannerCldPubId?: string;
+    subject?: Subject;
+    teacher?: User;
+    department?: Department;
+    schedules: Schedule[];
+    inviteCode?: string;
+};
+
+export type SignUpPayload = {
+    email: string;
+    name: string;
+    password: string;
+    image?: string;
+    imageCldPubId?: string;
+    role: UserRole;
+};


### PR DESCRIPTION

✅ COMPLETED (close these issues):

#45 Mock Data Provider — data.ts fully implemented with getList, mock subjects, and stub methods
#46 Subject Filtration queries — searchFilters and departmentFilters implemented in lists.tsx
#7 Subjects Page UI — full lists.tsx with table, search, department dropdown, breadcrumb, create button
#13 Reusable Table Component — DataTable being consumed via subjectTable
#12 Navigation Breadcrumbs — <Breadcrumb/> component used in subjects page


🔄 CURRENTLY IN PROGRESS (your active branch):

#30 Set Up Data Provider — partially done (mock version complete, real REST version pending)