### PR TITLE
feat: Define database schema with departments and subjects tables

### DIFF
--- a/bitcourse-backend/drizzle/0000_sudden_pyro.sql
+++ b/bitcourse-backend/drizzle/0000_sudden_pyro.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "departments" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "departments_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"code" varchar(50) NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" varchar(255),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "departments_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "subjects" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "subjects_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"department_id" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"code" varchar(50) NOT NULL,
+	"description" varchar(255),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "subjects_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+ALTER TABLE "subjects" ADD CONSTRAINT "subjects_department_id_departments_id_fk" FOREIGN KEY ("department_id") REFERENCES "public"."departments"("id") ON DELETE restrict ON UPDATE no action;

--- a/bitcourse-backend/drizzle/meta/0000_snapshot.json
+++ b/bitcourse-backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,179 @@
+{
+  "id": "e150420c-9d24-4a6a-9e3a-22c558e7c1b4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.departments": {
+      "name": "departments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "departments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "departments_code_unique": {
+          "name": "departments_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subjects": {
+      "name": "subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "subjects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subjects_department_id_departments_id_fk": {
+          "name": "subjects_department_id_departments_id_fk",
+          "tableFrom": "subjects",
+          "tableTo": "departments",
+          "columnsFrom": [
+            "department_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subjects_code_unique": {
+          "name": "subjects_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/bitcourse-backend/drizzle/meta/_journal.json
+++ b/bitcourse-backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773259906472,
+      "tag": "0000_sudden_pyro",
+      "breakpoints": true
+    }
+  ]
+}

--- a/bitcourse-backend/package.json
+++ b/bitcourse-backend/package.json
@@ -6,7 +6,9 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate"
   },
   "keywords": [],
   "author": "",

--- a/bitcourse-backend/src/db/schema/app.ts
+++ b/bitcourse-backend/src/db/schema/app.ts
@@ -1,0 +1,38 @@
+import { integer, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import {relations} from "drizzle-orm";
+
+const timestamps = {
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().$onUpdate(() => new Date()).notNull()
+}
+
+export const departments = pgTable('departments', {
+    id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+    code: varchar('code', {length: 50}).notNull().unique(),
+    name: varchar('name', {length: 255}).notNull(),
+    description: varchar('description', {length: 255}),
+    ...timestamps
+});
+
+export const subjects = pgTable('subjects', {
+    id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+    departmentId: integer('department_id').notNull().references(() => departments.id, { onDelete: 'restrict' }),
+    name: varchar('name', {length: 255}).notNull(),
+    code: varchar('code', {length: 50}).notNull().unique(),
+    description: varchar('description', {length: 255}),
+    ...timestamps
+});
+
+export const departmentRelations = relations(departments, ({ many }) => ({ subjects: many(subjects) }))
+export const subjectsRelations = relations(subjects, ({ one, many }) => ({
+    department: one(departments, {
+        fields: [subjects.departmentId],
+        references: [departments.id],
+    })
+}));
+
+export type Department = typeof departments.$inferSelect;
+export type NewDepartment = typeof departments.$inferInsert;
+
+export type Subject = typeof subjects.$inferSelect;
+export type NewSubject = typeof subjects.$inferInsert;


### PR DESCRIPTION
## Summary
Defines the core database schema for the BitCourse application using Drizzle ORM.

## Changes
- Created `src/db/schema/app.ts` with departments and subjects table definitions
- Added shared `timestamps` object (createdAt, updatedAt) reused across tables
- Defined foreign key relationship: subjects reference departments with onDelete restrict
- Added Drizzle relations for departments (one-to-many subjects) and subjects (many-to-one department)
- Exported TypeScript types: Department, NewDepartment, Subject, NewSubject
- Created `src/db/schema/index.ts` as barrel export file

## Issues Resolved
Closes #42 - Database Schema Set Up
Closes #46 - Subject Filtration queries (partial - schema foundation)

## Notes
- Schema uses generatedAlwaysAsIdentity() for primary keys
- Relations configured for type-safe joins in future queries