### PR TITLE
feat: Classes pages - list, create, and show views

### DIFF
--- a/bitcourse-frontend/src/App.tsx
+++ b/bitcourse-frontend/src/App.tsx
@@ -13,10 +13,13 @@ import { useNotificationProvider } from "./components/refine-ui/notification/use
 import { ThemeProvider } from "./components/refine-ui/theme/theme-provider";
 import { dataProvider } from "./providers/data";
 import Dashboard from "@/pages/Dashboard.tsx";
-import {BookOpen, Home} from "lucide-react";
+import {BookOpen, GraduationCap, Home} from "lucide-react";
 import {Layout} from "@/components/refine-ui/layout/layout.tsx";
 import SubjectsLists from "@/pages/subjects/lists.tsx";
 import SubjectsCreate from "@/pages/subjects/create.tsx";
+import ClassesList from "@/pages/classes/list.tsx";
+import ClassesCreate from "@/pages/classes/create.tsx";
+import ClassesShow from "@/pages/classes/show.tsx";
 
 function App() {
   return (
@@ -45,6 +48,16 @@ function App() {
                       create: '/subjects/create',
                       meta: {label: 'Subjects', icon: <BookOpen />}
                   },
+                  {
+                      name: "classes",
+                      list: "/classes",
+                      create: "/classes/create",
+                      show: "/classes/show/:id",
+                      meta: {
+                          label: "Classes",
+                          icon: <GraduationCap/>,
+                      },
+                  },
               ]}
             >
               <Routes>
@@ -54,10 +67,16 @@ function App() {
                           </Layout>
                       }>
                         <Route path="/" element={<Dashboard />}/>
+
                         <Route path="subjects">
                             <Route index element={<SubjectsLists/>} />
                             <Route path={"create"} element={<SubjectsCreate/>} />
+                        </Route>
 
+                        <Route path="classes">
+                            <Route index element={<ClassesList />} />
+                            <Route path="create" element={<ClassesCreate />} />
+                            <Route path="show/:id" element={<ClassesShow />} />
                         </Route>
 
                       </Route>

--- a/bitcourse-frontend/src/lib/schema.ts
+++ b/bitcourse-frontend/src/lib/schema.ts
@@ -1,0 +1,71 @@
+import * as z from "zod";
+
+export const facultySchema = z.object({
+    name: z.string().min(2, "Name must be at least 2 characters"),
+    email: z.string().email("Invalid email address"),
+    role: z.enum(["admin", "teacher", "student"], {
+        required_error: "Please select a role",
+    }),
+    department: z.string(),
+    image: z.string().optional(),
+    imageCldPubId: z.string().optional(),
+});
+
+export const subjectSchema = z.object({
+    name: z.string().min(3, "Subject name must be at least 3 characters"),
+    code: z.string().min(5, "Subject code must be at least 5 characters"),
+    description: z
+        .string()
+        .min(5, "Subject description must be at least 5 characters"),
+    department: z
+        .string()
+        .min(2, "Subject department must be at least 2 characters"),
+});
+
+const scheduleSchema = z.object({
+    day: z.string().min(1, "Day is required"),
+    startTime: z.string().min(1, "Start time is required"),
+    endTime: z.string().min(1, "End time is required"),
+});
+
+export const classSchema = z.object({
+    name: z
+        .string()
+        .min(2, "Class name must be at least 2 characters")
+        .max(50, "Class name must be at most 50 characters"),
+    description: z
+        .string({ required_error: "Description is required" })
+        .min(5, "Description must be at least 5 characters"),
+    subjectId: z.coerce
+        .number({
+            required_error: "Subject is required",
+            invalid_type_error: "Subject is required",
+        })
+        .min(1, "Subject is required"),
+    teacherId: z.string().min(1, "Teacher is required"),
+    capacity: z.coerce
+        .number({
+            required_error: "Capacity is required",
+            invalid_type_error: "Capacity is required",
+        })
+        .min(1, "Capacity must be at least 1"),
+    status: z.enum(["active", "inactive"]),
+    bannerUrl: z
+        .string({ required_error: "Class banner is required" })
+        .min(1, "Class banner is required"),
+    bannerCldPubId: z
+        .string({ required_error: "Banner reference is required" })
+        .min(1, "Banner reference is required"),
+    inviteCode: z.string().optional(),
+    schedules: z.array(scheduleSchema).optional(),
+});
+
+export const enrollmentSchema = z.object({
+    classId: z.coerce
+        .number({
+            required_error: "Class ID is required",
+            invalid_type_error: "Class ID is required",
+        })
+        .min(1, "Class ID is required"),
+    studentId: z.string().min(1, "Student ID is required"),
+});

--- a/bitcourse-frontend/src/pages/classes/create.tsx
+++ b/bitcourse-frontend/src/pages/classes/create.tsx
@@ -1,0 +1,349 @@
+import { useForm } from "@refinedev/react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+import { CreateView } from "@/components/refine-ui/views/create-view";
+import { Breadcrumb } from "@/components/refine-ui/layout/breadcrumb";
+
+import { Textarea } from "@/components/ui/textarea";
+import { useBack, useList } from "@refinedev/core";
+import { Loader2 } from "lucide-react";
+import { classSchema } from "@/lib/schema";
+import UploadWidget from "@/components/upload-widget";
+import { Subject, User } from "@/types";
+import z from "zod";
+
+const ClassesCreate = () => {
+    const back = useBack();
+
+    const form = useForm({
+        resolver: zodResolver(classSchema),
+        refineCoreProps: {
+            resource: "classes",
+            action: "create",
+        },
+        defaultValues: {
+            status: "active",
+        },
+    });
+
+    const {
+        refineCore: { onFinish },
+        handleSubmit,
+        formState: { isSubmitting, errors },
+        control,
+    } = form;
+
+    const bannerPublicId = form.watch("bannerCldPubId");
+
+    const onSubmit = async (values: z.infer<typeof classSchema>) => {
+        try {
+            await onFinish(values);
+        } catch (error) {
+            console.error("Error creating class:", error);
+        }
+    };
+
+    // Fetch subjects list
+    const { query: subjectsQuery } = useList<Subject>({
+        resource: "subjects",
+        pagination: {
+            pageSize: 100,
+        },
+    });
+
+    // Fetch teachers list
+    const { query: teachersQuery } = useList<User>({
+        resource: "users",
+        filters: [
+            {
+                field: "role",
+                operator: "eq",
+                value: "teacher",
+            },
+        ],
+        pagination: {
+            pageSize: 100,
+        },
+    });
+
+    const teachers = teachersQuery.data?.data || [];
+    const teachersLoading = teachersQuery.isLoading;
+
+    const subjects = subjectsQuery.data?.data || [];
+    const subjectsLoading = subjectsQuery.isLoading;
+
+    return (
+        <CreateView className="class-view">
+            <Breadcrumb />
+
+            <h1 className="page-title">Create a Class</h1>
+            <div className="intro-row">
+                <p>Provide the required information below to add a class.</p>
+                <Button onClick={() => back()}>Go Back</Button>
+            </div>
+
+            <Separator />
+
+            <div className="my-4 flex items-center">
+                <Card className="class-form-card">
+                    <CardHeader className="relative z-10">
+                        <CardTitle className="text-2xl pb-0 font-bold text-gradient-orange">
+                            Fill out form
+                        </CardTitle>
+                    </CardHeader>
+
+                    <Separator />
+
+                    <CardContent className="mt-7">
+                        <Form {...form}>
+                            <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+                                <FormField
+                                    control={control}
+                                    name="bannerUrl"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>
+                                                Banner Image <span className="text-orange-600">*</span>
+                                            </FormLabel>
+                                            <FormControl>
+                                                <UploadWidget
+                                                    value={
+                                                        field.value
+                                                            ? {
+                                                                url: field.value,
+                                                                publicId: bannerPublicId ?? "",
+                                                            }
+                                                            : null
+                                                    }
+                                                    onChange={(file) => {
+                                                        if (file) {
+                                                            field.onChange(file.url);
+                                                            form.setValue("bannerCldPubId", file.publicId, {
+                                                                shouldValidate: true,
+                                                                shouldDirty: true,
+                                                            });
+                                                        } else {
+                                                            field.onChange("");
+                                                            form.setValue("bannerCldPubId", "", {
+                                                                shouldValidate: true,
+                                                                shouldDirty: true,
+                                                            });
+                                                        }
+                                                    }}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                            {errors.bannerCldPubId && !errors.bannerUrl && (
+                                                <p className="text-destructive text-sm">
+                                                    {errors.bannerCldPubId.message?.toString()}
+                                                </p>
+                                            )}
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={control}
+                                    name="name"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>
+                                                Class Name <span className="text-orange-600">*</span>
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    placeholder="Introduction to Biology - Section A"
+                                                    {...field}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <div className="grid sm:grid-cols-2 gap-4">
+                                    <FormField
+                                        control={control}
+                                        name="subjectId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>
+                                                    Subject <span className="text-orange-600">*</span>
+                                                </FormLabel>
+                                                <Select
+                                                    onValueChange={(value) =>
+                                                        field.onChange(Number(value))
+                                                    }
+                                                    value={field.value?.toString()}
+                                                    disabled={subjectsLoading}
+                                                >
+                                                    <FormControl>
+                                                        <SelectTrigger className="w-full">
+                                                            <SelectValue placeholder="Select a subject" />
+                                                        </SelectTrigger>
+                                                    </FormControl>
+                                                    <SelectContent>
+                                                        {subjects.map((subject) => (
+                                                            <SelectItem
+                                                                key={subject.id}
+                                                                value={subject.id.toString()}
+                                                            >
+                                                                {subject.name} ({subject.code})
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name="teacherId"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>
+                                                    Teacher <span className="text-orange-600">*</span>
+                                                </FormLabel>
+                                                <Select
+                                                    onValueChange={field.onChange}
+                                                    value={field.value?.toString()}
+                                                    disabled={teachersLoading}
+                                                >
+                                                    <FormControl>
+                                                        <SelectTrigger className="w-full">
+                                                            <SelectValue placeholder="Select a teacher" />
+                                                        </SelectTrigger>
+                                                    </FormControl>
+                                                    <SelectContent>
+                                                        {teachers.map((teacher) => (
+                                                            <SelectItem key={teacher.id} value={teacher.id}>
+                                                                {teacher.name}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+
+                                <div className="grid sm:grid-cols-2 gap-4">
+                                    <FormField
+                                        control={control}
+                                        name="capacity"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>
+                                                    Capacity <span className="text-orange-600">*</span>
+                                                </FormLabel>
+                                                <FormControl>
+                                                    <Input
+                                                        type="number"
+                                                        min={1}
+                                                        placeholder="30"
+                                                        onChange={(e) => {
+                                                            const value = e.target.value;
+                                                            field.onChange(value ? Number(value) : undefined);
+                                                        }}
+                                                        value={(field.value as number | undefined) ?? ""}
+                                                        name={field.name}
+                                                        ref={field.ref}
+                                                        onBlur={field.onBlur}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={control}
+                                        name="status"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>
+                                                    Status <span className="text-orange-600">*</span>
+                                                </FormLabel>
+                                                <Select
+                                                    onValueChange={field.onChange}
+                                                    value={field.value}
+                                                >
+                                                    <FormControl>
+                                                        <SelectTrigger className="w-full">
+                                                            <SelectValue placeholder="Select status" />
+                                                        </SelectTrigger>
+                                                    </FormControl>
+                                                    <SelectContent>
+                                                        <SelectItem value="active">Active</SelectItem>
+                                                        <SelectItem value="inactive">Inactive</SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+
+                                <FormField
+                                    control={control}
+                                    name="description"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>
+                                                Description <span className="text-orange-600">*</span>
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Textarea
+                                                    placeholder="Brief description about the class"
+                                                    {...field}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <Separator />
+
+                                <Button type="submit" size="lg" className="w-full">
+                                    {isSubmitting ? (
+                                        <div className="flex gap-1">
+                                            <span>Creating Class...</span>
+                                            <Loader2 className="inline-block ml-2 animate-spin" />
+                                        </div>
+                                    ) : (
+                                        "Create Class"
+                                    )}
+                                </Button>
+                            </form>
+                        </Form>
+                    </CardContent>
+                </Card>
+            </div>
+        </CreateView>
+    );
+};
+
+export default ClassesCreate;

--- a/bitcourse-frontend/src/pages/classes/list.tsx
+++ b/bitcourse-frontend/src/pages/classes/list.tsx
@@ -1,0 +1,288 @@
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { useTable } from "@refinedev/react-table";
+import { useList } from "@refinedev/core";
+
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { ListView } from "@/components/refine-ui/views/list-view";
+import { CreateButton } from "@/components/refine-ui/buttons/create";
+import { Breadcrumb } from "@/components/refine-ui/layout/breadcrumb";
+import { DataTable } from "@/components/refine-ui/data-table/data-table";
+import { ShowButton } from "@/components/refine-ui/buttons/show";
+
+import { Subject, User } from "@/types";
+
+type ClassListItem = {
+    id: number;
+    name: string;
+    status: "active" | "inactive";
+    bannerUrl?: string;
+    subject?: {
+        name: string;
+    };
+    teacher?: {
+        name: string;
+    };
+    capacity: number;
+};
+
+const ClassesList = () => {
+    const [searchQuery, setSearchQuery] = useState("");
+    const [selectedSubject, setSelectedSubject] = useState<string>("all");
+    const [selectedTeacher, setSelectedTeacher] = useState<string>("all");
+
+    const classColumns = useMemo<ColumnDef<ClassListItem>[]>(
+        () => [
+            {
+                id: "banner",
+                accessorKey: "bannerUrl",
+                size: 120,
+                header: () => <p className="column-title ml-2">Banner</p>,
+                cell: ({ getValue }) => {
+                    const bannerUrl = getValue<string>();
+
+                    return bannerUrl ? (
+                        <img
+                            src={bannerUrl}
+                            alt="Class banner"
+                            className="ml-2 h-10 w-10 rounded-md object-cover"
+                            loading="lazy"
+                        />
+                    ) : (
+                        <span className="text-muted-foreground ml-2">No image</span>
+                    );
+                },
+            },
+            {
+                id: "name",
+                accessorKey: "name",
+                size: 220,
+                header: () => <p className="column-title">Class Name</p>,
+                cell: ({ getValue }) => {
+                    const className = getValue<string>();
+
+                    return <span className="text-foreground">{className}</span>;
+                },
+            },
+            {
+                id: "status",
+                accessorKey: "status",
+                size: 140,
+                header: () => <p className="column-title">Status</p>,
+                cell: ({ getValue }) => {
+                    const status = getValue<"active" | "inactive">();
+                    const variant = status === "active" ? "default" : "secondary";
+
+                    return <Badge variant={variant}>{status}</Badge>;
+                },
+            },
+            {
+                id: "subject",
+                accessorKey: "subject.name",
+                size: 200,
+                header: () => <p className="column-title">Subject</p>,
+                cell: ({ getValue }) => {
+                    const subjectName = getValue<string>();
+
+                    return subjectName ? (
+                        <Badge variant="secondary">{subjectName}</Badge>
+                    ) : (
+                        <span className="text-muted-foreground">Not set</span>
+                    );
+                },
+            },
+            {
+                id: "teacher",
+                accessorKey: "teacher.name",
+                size: 200,
+                header: () => <p className="column-title">Teacher</p>,
+                cell: ({ getValue }) => {
+                    const teacherName = getValue<string>();
+
+                    return teacherName ? (
+                        <span className="text-foreground">{teacherName}</span>
+                    ) : (
+                        <span className="text-muted-foreground">Not assigned</span>
+                    );
+                },
+            },
+            {
+                id: "capacity",
+                accessorKey: "capacity",
+                size: 120,
+                header: () => <p className="column-title">Capacity</p>,
+                cell: ({ getValue }) => {
+                    const capacity = getValue<number>();
+
+                    return <span className="text-foreground">{capacity}</span>;
+                },
+            },
+            {
+                id: "details",
+                size: 140,
+                header: () => <p className="column-title">Details</p>,
+                cell: ({ row }) => (
+                    <ShowButton
+                        resource="classes"
+                        recordItemId={row.original.id}
+                        variant="outline"
+                        size="sm"
+                    >
+                        View
+                    </ShowButton>
+                ),
+            },
+        ],
+        []
+    );
+
+    const { query: subjectsQuery } = useList<Subject>({
+        resource: "subjects",
+        pagination: {
+            pageSize: 100,
+        },
+    });
+
+    const { query: teachersQuery } = useList<User>({
+        resource: "users",
+        filters: [
+            {
+                field: "role",
+                operator: "eq",
+                value: "teacher",
+            },
+        ],
+        pagination: {
+            pageSize: 100,
+        },
+    });
+
+    const subjects = subjectsQuery.data?.data || [];
+    const teachers = teachersQuery.data?.data || [];
+
+    const subjectFilters =
+        selectedSubject === "all"
+            ? []
+            : [
+                {
+                    field: "subject",
+                    operator: "eq" as const,
+                    value: selectedSubject,
+                },
+            ];
+
+    const teacherFilters =
+        selectedTeacher === "all"
+            ? []
+            : [
+                {
+                    field: "teacher",
+                    operator: "eq" as const,
+                    value: selectedTeacher,
+                },
+            ];
+
+    const searchFilters = searchQuery
+        ? [
+            {
+                field: "name",
+                operator: "contains" as const,
+                value: searchQuery,
+            },
+        ]
+        : [];
+
+    const classesTable = useTable<ClassListItem>({
+        columns: classColumns,
+        refineCoreProps: {
+            resource: "classes",
+            pagination: {
+                pageSize: 10,
+                mode: "server",
+            },
+            filters: {
+                // Compose refine filters from the current UI selections.
+                permanent: [...subjectFilters, ...teacherFilters, ...searchFilters],
+            },
+            sorters: {
+                initial: [
+                    {
+                        field: "id",
+                        order: "desc",
+                    },
+                ],
+            },
+        },
+    });
+
+    return (
+        <ListView>
+            <Breadcrumb />
+            <h1 className="page-title">Classes</h1>
+
+            <div className="intro-row">
+                <p>Quick access to essential metrics and management tools.</p>
+
+                <div className="actions-row">
+                    <div className="search-field">
+                        <Search className="search-icon" />
+                        <Input
+                            type="text"
+                            placeholder="Search by name..."
+                            className="pl-10 w-full"
+                            value={searchQuery}
+                            onChange={(event) => setSearchQuery(event.target.value)}
+                        />
+                    </div>
+
+                    <div className="flex gap-2 w-full sm:w-auto">
+                        <Select value={selectedSubject} onValueChange={setSelectedSubject}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Filter by subject" />
+                            </SelectTrigger>
+
+                            <SelectContent>
+                                <SelectItem value="all">All Subjects</SelectItem>
+                                {subjects.map((subject) => (
+                                    <SelectItem key={subject.id} value={subject.name}>
+                                        {subject.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+
+                        <Select value={selectedTeacher} onValueChange={setSelectedTeacher}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Filter by teacher" />
+                            </SelectTrigger>
+
+                            <SelectContent>
+                                <SelectItem value="all">All Teachers</SelectItem>
+                                {teachers.map((teacher) => (
+                                    <SelectItem key={teacher.id} value={teacher.name}>
+                                        {teacher.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+
+                        <CreateButton resource="classes" />
+                    </div>
+                </div>
+            </div>
+
+            <DataTable table={classesTable} />
+        </ListView>
+    );
+};
+
+export default ClassesList;

--- a/bitcourse-frontend/src/pages/classes/show.tsx
+++ b/bitcourse-frontend/src/pages/classes/show.tsx
@@ -1,0 +1,260 @@
+//import { AdvancedImage } from "@cloudinary/react";
+import { useShow } from "@refinedev/core";
+import { useTable } from "@refinedev/react-table";
+import { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+import { useParams } from "react-router";
+
+import { DataTable } from "@/components/refine-ui/data-table/data-table";
+import { ShowButton } from "@/components/refine-ui/buttons/show";
+import {
+    ShowView,
+    ShowViewHeader,
+} from "@/components/refine-ui/views/show-view";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+//import { bannerPhoto } from "@/lib/cloudinary";
+import { ClassDetails } from "@/types";
+
+type ClassUser = {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+    image?: string | null;
+};
+
+const ClassesShow = () => {
+    const { id } = useParams();
+    const classId = id ?? "";
+
+    const { query } = useShow<ClassDetails>({
+        resource: "classes",
+    });
+
+    const classDetails = query.data?.data;
+
+    const studentColumns = useMemo<ColumnDef<ClassUser>[]>(
+        () => [
+            {
+                id: "name",
+                accessorKey: "name",
+                size: 240,
+                header: () => <p className="column-title">Student</p>,
+                cell: ({ row }) => (
+                    <div className="flex items-center gap-2">
+                        <Avatar className="size-7">
+                            {row.original.image && (
+                                <AvatarImage src={row.original.image} alt={row.original.name} />
+                            )}
+                            <AvatarFallback>{getInitials(row.original.name)}</AvatarFallback>
+                        </Avatar>
+                        <div className="flex flex-col truncate">
+                            <span className="truncate">{row.original.name}</span>
+                            <span className="text-xs text-muted-foreground truncate">
+                {row.original.email}
+              </span>
+                        </div>
+                    </div>
+                ),
+            },
+            {
+                id: "details",
+                size: 140,
+                header: () => <p className="column-title">Details</p>,
+                cell: ({ row }) => (
+                    <ShowButton
+                        resource="users"
+                        recordItemId={row.original.id}
+                        variant="outline"
+                        size="sm"
+                    >
+                        View
+                    </ShowButton>
+                ),
+            },
+        ],
+        []
+    );
+
+    const studentsTable = useTable<ClassUser>({
+        columns: studentColumns,
+        refineCoreProps: {
+            resource: `classes/${classId}/users`,
+            pagination: {
+                pageSize: 3,
+                mode: "server",
+            },
+            filters: {
+                permanent: [
+                    {
+                        field: "role",
+                        operator: "eq",
+                        value: "student",
+                    },
+                ],
+            },
+        },
+    });
+
+    if (query.isLoading || query.isError || !classDetails) {
+        return (
+            <ShowView className="class-view class-show">
+                <ShowViewHeader resource="classes" title="Class Details" />
+                <p className="state-message">
+                    {query.isLoading
+                        ? "Loading class details..."
+                        : query.isError
+                            ? "Failed to load class details."
+                            : "Class details not found."}
+                </p>
+            </ShowView>
+        );
+    }
+
+    const teacherName = classDetails.teacher?.name ?? "Unknown";
+    const teacherInitials = teacherName
+        .split(" ")
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase())
+        .join("");
+
+    const placeholderUrl = `https://placehold.co/600x400?text=${encodeURIComponent(
+        teacherInitials || "NA"
+    )}`;
+
+    return (
+        <ShowView className="class-view class-show space-y-6">
+            <ShowViewHeader resource="classes" title="Class Details" />
+
+            <div className="banner">
+                {classDetails.bannerUrl ? (
+                    classDetails.bannerUrl.includes("res.cloudinary.com") &&
+                    classDetails.bannerCldPubId ? (
+                        <AdvancedImage
+                            cldImg={bannerPhoto(
+                                classDetails.bannerCldPubId ?? "",
+                                classDetails.name
+                            )}
+                            alt="Class Banner"
+                        />
+                    ) : (
+                        <img
+                            src={classDetails.bannerUrl}
+                            alt={classDetails.name}
+                            loading="lazy"
+                        />
+                    )
+                ) : (
+                    <div className="placeholder" />
+                )}
+            </div>
+
+            <Card className="details-card">
+                {/* Class Details */}
+                <div>
+                    <div className="details-header">
+                        <div>
+                            <h1>{classDetails.name}</h1>
+                            <p>{classDetails.description}</p>
+                        </div>
+
+                        <div>
+                            <Badge variant="outline">{classDetails.capacity} spots</Badge>
+                            <Badge
+                                variant={
+                                    classDetails.status === "active" ? "default" : "secondary"
+                                }
+                                data-status={classDetails.status}
+                            >
+                                {classDetails.status.toUpperCase()}
+                            </Badge>
+                        </div>
+                    </div>
+
+                    <div className="details-grid">
+                        <div className="instructor">
+                            <p>👨‍🏫 Instructor</p>
+                            <div>
+                                <img
+                                    src={classDetails.teacher?.image ?? placeholderUrl}
+                                    alt={teacherName}
+                                />
+
+                                <div>
+                                    <p>{teacherName}</p>
+                                    <p>{classDetails?.teacher?.email}</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="department">
+                            <p>🏛️ Department</p>
+
+                            <div>
+                                <p>{classDetails?.department?.name}</p>
+                                <p>{classDetails?.department?.description}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <Separator />
+
+                {/* Subject Card */}
+                <div className="subject">
+                    <p>📚 Subject</p>
+
+                    <div>
+                        <Badge variant="outline">
+                            Code: <span>{classDetails?.subject?.code}</span>
+                        </Badge>
+                        <p>{classDetails?.subject?.name}</p>
+                        <p>{classDetails?.subject?.description}</p>
+                    </div>
+                </div>
+
+                <Separator />
+
+                {/* Join Class Section */}
+                <div className="join">
+                    <h2>🎓 Join Class</h2>
+
+                    <ol>
+                        <li>Ask your teacher for the invite code.</li>
+                        <li>Click on &quot;Join Class&quot; button.</li>
+                        <li>Paste the code and click &quot;Join&quot;</li>
+                    </ol>
+                </div>
+
+                <Button size="lg" className="w-full">
+                    Join Class
+                </Button>
+            </Card>
+
+            <Card className="hover:shadow-md transition-shadow">
+                <CardHeader className="flex flex-row items-center justify-between">
+                    <CardTitle>Enrolled Students</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <DataTable table={studentsTable} paginationVariant="simple" />
+                </CardContent>
+            </Card>
+        </ShowView>
+    );
+};
+
+const getInitials = (name = "") => {
+    const parts = name.trim().split(" ").filter(Boolean);
+    if (parts.length === 0) return "";
+    if (parts.length === 1) return parts[0][0]?.toUpperCase() ?? "";
+    return `${parts[0][0] ?? ""}${
+        parts[parts.length - 1][0] ?? ""
+    }`.toUpperCase();
+};
+
+export default ClassesShow;


### PR DESCRIPTION
## Summary
Implements the full Classes feature with three pages: a filterable list view, a create form, and a detailed show page.

## Changes

### `pages/classes/list.tsx`
- Classes list table with columns: banner image, name, status, subject, teacher, capacity
- Search by class name
- Filter by subject and teacher via dropdowns
- Server-side pagination
- CreateButton for adding new classes

### `pages/classes/create.tsx`
- Create class form with Zod validation
- Fields: banner image (Cloudinary upload), class name, subject, teacher, capacity, status, description
- Dynamically fetches subjects and teachers from API for select dropdowns
- Loading state on submit button

### `pages/classes/show.tsx`
- Detailed class view with banner image (Cloudinary-aware)
- Displays instructor info, department, subject details
- Enrolled students table with avatar, name, email
- Join Class section with invite code instructions
- Badge indicators for status and capacity

## Issues Resolved
Closes #5 - Classes Page UI
Closes #17 - Create Class Form
Closes #21 - Class Form Validation
Closes #22 - Cloudinary Integration (partial - upload widget used in form)