### PR TITLE
feat: Cloudinary upload widget component

### DIFF
--- a/bitcourse-frontend/index.html
+++ b/bitcourse-frontend/index.html
@@ -27,15 +27,9 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm dev` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
+    <script
+            src="https://upload-widget.cloudinary.com/latest/global/all.js"
+            type="text/javascript"
+    ></script>
   </body>
 </html>

--- a/bitcourse-frontend/src/components/upload-widget.tsx
+++ b/bitcourse-frontend/src/components/upload-widget.tsx
@@ -1,0 +1,152 @@
+import { CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET } from "@/constants";
+import { Trash, UploadCloud } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "./ui/button";
+import { UploadWidgetProps, UploadWidgetValue } from "@/types";
+
+function UploadWidget({
+                          value = null,
+                          onChange,
+                          disabled = false,
+                      }: UploadWidgetProps) {
+    const widgetRef = useRef<CloudinaryWidget | null>(null);
+    const onChangeRef = useRef(onChange);
+
+    const [preview, setPreview] = useState<UploadWidgetValue | null>(value);
+    const [deleteToken, setDeleteToken] = useState<string | null>(null);
+    const [isRemoving, setIsRemoving] = useState(false);
+
+    // Always keep latest onChange
+    useEffect(() => {
+        onChangeRef.current = onChange;
+    }, [onChange]);
+
+    // Sync external value → internal preview
+    useEffect(() => {
+        setPreview(value);
+        if (!value) {
+            setDeleteToken(null);
+        }
+    }, [value]);
+
+    // Initialize Cloudinary widget (client-side only)
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+
+        const initializeWidget = () => {
+            if (!window.cloudinary || widgetRef.current) return false;
+
+            widgetRef.current = window.cloudinary.createUploadWidget(
+                {
+                    cloudName: CLOUDINARY_CLOUD_NAME,
+                    uploadPreset: CLOUDINARY_UPLOAD_PRESET,
+                    multiple: false,
+                    folder: "uploads",
+                    maxFileSize: 5_000_000,
+                    clientAllowedFormats: ["png", "jpg", "jpeg"],
+                },
+                (error, result) => {
+                    if (!error && result.event === "success") {
+                        const payload: UploadWidgetValue = {
+                            url: result.info.secure_url,
+                            publicId: result.info.public_id,
+                        };
+
+                        setPreview(payload);
+                        setDeleteToken(result.info.delete_token ?? null);
+                        onChangeRef.current?.(payload);
+                    }
+                }
+            );
+
+            return true;
+        };
+
+        if (initializeWidget()) return;
+
+        const intervalId = window.setInterval(() => {
+            if (initializeWidget()) {
+                window.clearInterval(intervalId);
+            }
+        }, 500);
+
+        return () => window.clearInterval(intervalId);
+    }, []);
+
+    const openWidget = () => {
+        if (!disabled) {
+            widgetRef.current?.open();
+        }
+    };
+
+    const removeFromCloudinary = async () => {
+        if (!preview) return;
+
+        setIsRemoving(true);
+
+        try {
+            if (deleteToken) {
+                const params = new URLSearchParams();
+                params.append("token", deleteToken);
+
+                await fetch(
+                    `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/delete_by_token`,
+                    {
+                        method: "POST",
+                        body: params,
+                    }
+                );
+            }
+        } catch (error) {
+            console.error("Failed to remove image from Cloudinary", error);
+        } finally {
+            setPreview(null);
+            setDeleteToken(null);
+            onChangeRef.current?.(null);
+            setIsRemoving(false);
+        }
+    };
+
+    return (
+        <div className="space-y-2">
+            {preview ? (
+                <div className="upload-preview">
+                    <img src={preview.url} alt="Uploaded file" />
+
+                    <Button
+                        type="button"
+                        size="icon"
+                        variant="destructive"
+                        onClick={removeFromCloudinary}
+                        disabled={isRemoving || disabled}
+                    >
+                        <Trash className="size-4" />
+                    </Button>
+                </div>
+            ) : (
+                <div
+                    className="upload-dropzone"
+                    role="button"
+                    tabIndex={0}
+                    onClick={openWidget}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            openWidget();
+                        }
+                    }}
+                >
+                    <div className="upload-prompt">
+                        <UploadCloud className="icon" />
+                        <div>
+                            <p>Click to upload photo</p>
+                            <p>PNG, JPG up to 5MB</p>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default UploadWidget;


### PR DESCRIPTION
## Summary
Adds a reusable Cloudinary upload widget component for image uploading across the application (currently used in the class create form for banner images).

## Changes
- Created `components/upload-widget.tsx` with full Cloudinary upload integration
- Lazy-initializes the Cloudinary widget via `window.cloudinary` with polling fallback
- Supports upload preview with image display after successful upload
- Delete button removes image from Cloudinary via `delete_by_token`
- Syncs with external form state via `value`/`onChange` props
- Configured for PNG/JPG uploads up to 5MB, stored in `uploads/` folder
- Added `.env` variables: `VITE_CLOUDINARY_CLOUD_NAME`, `VITE_CLOUDINARY_UPLOAD_PRESET`, `VITE_CLOUDINARY_UPLOAD_URL`

## Issues Resolved
Closes #22 - Cloudinary Integration