### PR TITLE
feat: Isaac-ArcJetMiddleware

### DIFF
--- a/bitcourse-backend/package-lock.json
+++ b/bitcourse-backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@arcjet/inspect": "^1.4.0",
+        "@arcjet/node": "^1.4.0",
         "@neondatabase/serverless": "^1.0.2",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
@@ -24,6 +26,220 @@
         "drizzle-kit": "^0.31.9",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@arcjet/analyze": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze/-/analyze-1.4.0.tgz",
+      "integrity": "sha512-dKvRoAnhNRHVuHnQZ4LxL8yH7CVrP4uDhfvoN26aqDuAwjLkJZSR1PzGzj1OH91jD1Qqthn/+wzNm7lqPEjJDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/analyze-wasm": "1.4.0",
+        "@arcjet/protocol": "1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/analyze-wasm": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/analyze-wasm/-/analyze-wasm-1.4.0.tgz",
+      "integrity": "sha512-UHyTqz0rQqBccJIWmTPoeKreq3dvZ6Ql5loLY2S0nukA+wBMaBh1Ok88Vo8+qoT10Qkyh9FXk6famNhSiNS/nw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/body": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/body/-/body-1.4.0.tgz",
+      "integrity": "sha512-feR887vz8X/jQH8EpztkIdRzY3RnfKjGNBqFIqy2cb+EhxEGmGXJxq+tb0UFndoZ0UIaby+eofDhXUy/4uiF0w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/cache": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/cache/-/cache-1.4.0.tgz",
+      "integrity": "sha512-hRk2p2ZgZmcl1jv66VfbAXxKk7HghdMwFXWcn0wIjHa+ngaYRQFkfrEE0epWeHyTB/sI/p/3+MOT0ApbzIyY5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/duration": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/duration/-/duration-1.4.0.tgz",
+      "integrity": "sha512-5LzFCwMjaYTArKD+8ChZSUT9e2V8RJHqtHcRme/Q5k55ctjiCY+buMcxXSPcft85PpMGW229XKyO3nJSXr6t/A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/env": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/env/-/env-1.4.0.tgz",
+      "integrity": "sha512-zR9du8LpqdHcMQWZPhQeZr7zapf+EFNGjqHEjmAl/7tnJJUckaUGVJtFiSLBpu2mUYlhnMnwM8LRh2KF+45ecQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/headers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/headers/-/headers-1.4.0.tgz",
+      "integrity": "sha512-hzK0jM+sNXZT/dnN6gPSOBiqBODnIuVgFNZG/WHT49VZec9g+nU3X6JFxX5Tm2dIRtVcgQcBpNSgSb1vbWtUiQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/inspect": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/inspect/-/inspect-1.4.0.tgz",
+      "integrity": "sha512-+YZCUerZDboIapzTRBlnTeiQFvyPTEPxlQwDhew2/TKHPLr1/Mh+T5afUJzfT98D2/XUlmIKCLT++ULPd+7jIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/protocol": "1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/ip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/ip/-/ip-1.4.0.tgz",
+      "integrity": "sha512-gTmtauz5tyuhTaFT8WqS5O7RhpNnJSqK2RO3Hjr1iZydGI2YFkfNoNHjIU8Jck9A281nlHyQTTj3X+ZP51LCfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-pAZf78iZ81IezMl5qSbPokY20ma/dNic+w6Q61yOtf7RKfyvIrjWf4ml/CBwrFXodsOLpzeX96TylUudU3/wfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/sprintf": "1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/node/-/node-1.4.0.tgz",
+      "integrity": "sha512-yeVCd4WN+b5X5+IVMj9NZlmNK+YzG4TI377Zs4oM7SrS+lNz2YMFZSyXiJXww3F7RjV9pKfBGAjxY44bn7C8uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/body": "1.4.0",
+        "@arcjet/env": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/ip": "1.4.0",
+        "@arcjet/logger": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/transport": "1.4.0",
+        "arcjet": "1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/protocol": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/protocol/-/protocol-1.4.0.tgz",
+      "integrity": "sha512-CklnpCQ7WIsDa/Bw0ke46B0xs7RsAyXxflB2yRjCUb5yCw2JkfSGqCFLipDUDfI6G9dAFWJ3WZaJYidHDw9/Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/cache": "1.4.0",
+        "@bufbuild/protobuf": "2.11.0",
+        "@connectrpc/connect": "2.1.1",
+        "typeid-js": "1.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/runtime/-/runtime-1.4.0.tgz",
+      "integrity": "sha512-bjhzAqGjJwJnjvsbjqR1lpHdKQgbhLwpc+uvgZj5yIhiXCnJTZF+Erq2dsyebvZ8foDasO9iy6gLuTA1Nxeayw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/sprintf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/sprintf/-/sprintf-1.4.0.tgz",
+      "integrity": "sha512-FVrnyJO/0TIokkuXD+RmxK3SZrRhWQJxXnIm9af4U/2rrPzwD/X59t9ba2YW4ENIbVOhhUIUDD6sPfmsLyTl5g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/stable-hash": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/stable-hash/-/stable-hash-1.4.0.tgz",
+      "integrity": "sha512-8im/JZ8NgtXMx49xJM9w1x7+jzIapDD8HGPqb4JcxCjzMMymXpOCjbQINDPL5Pn5/0aG5C9wBWNuoJtWMSuFGQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arcjet/transport": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@arcjet/transport/-/transport-1.4.0.tgz",
+      "integrity": "sha512-EGCtY0sZwAJsYc21xbJlz6G+Cv++wPHA45WhzcKTAjJydDyhKSKgE9cM/+5EVmjGE5SHG6ctPwjqxEkV/jR4cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.11.0",
+        "@connectrpc/connect": "2.1.1",
+        "@connectrpc/connect-node": "2.1.1",
+        "@connectrpc/connect-web": "2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
+      "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.1.tgz",
+      "integrity": "sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.1"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.1.tgz",
+      "integrity": "sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.1"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1078,6 +1294,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/arcjet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/arcjet/-/arcjet-1.4.0.tgz",
+      "integrity": "sha512-x7nRRdV1IEYJHotTBZatBuwha8kjKrv7azOLM6HPpjRMY0nutZBe9PBs8RGAPiaCVl0EFG8VLaYieFbX4X8nMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@arcjet/analyze": "1.4.0",
+        "@arcjet/cache": "1.4.0",
+        "@arcjet/duration": "1.4.0",
+        "@arcjet/headers": "1.4.0",
+        "@arcjet/protocol": "1.4.0",
+        "@arcjet/runtime": "1.4.0",
+        "@arcjet/stable-hash": "1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/body-parser": {
@@ -2728,6 +2962,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typeid-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typeid-js/-/typeid-js-1.2.0.tgz",
+      "integrity": "sha512-t76ZucAnvGC60ea/HjVsB0TSoB0cw9yjnfurUgtInXQWUI/VcrlZGpO23KN3iSe8yOGUgb1zr7W7uEzJ3hSljA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2755,6 +2998,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/bitcourse-backend/package.json
+++ b/bitcourse-backend/package.json
@@ -16,6 +16,8 @@
   "description": "",
   "type": "module",
   "dependencies": {
+    "@arcjet/inspect": "^1.4.0",
+    "@arcjet/node": "^1.4.0",
     "@neondatabase/serverless": "^1.0.2",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",

--- a/bitcourse-backend/src/config/arcjet.ts
+++ b/bitcourse-backend/src/config/arcjet.ts
@@ -1,0 +1,31 @@
+import arcjet, { shield, detectBot, slidingWindow } from "@arcjet/node";
+
+if (!process.env.ARCJET_KEY && process.env.NODE_ENV !== "test") {
+    throw new Error(
+        "ARCJET_KEY environment variable is required. Sign up for your Arcjet key at https://app.arcjet.com"
+    );
+}
+
+// Configure Arcjet with security rules.
+const aj = arcjet({
+    key: process.env.ARCJET_KEY!,
+    rules: [
+        shield({ mode: "LIVE" }),
+        // Create a bot detection rule
+        detectBot({
+            mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
+            // Block all bots except the following
+            allow: [
+                "CATEGORY:SEARCH_ENGINE",
+                "CATEGORY:PREVIEW",
+            ],
+        }),
+        slidingWindow({
+            mode: "LIVE",
+            interval: "2s",
+            max: 5,
+        }),
+    ],
+});
+
+export default aj;

--- a/bitcourse-backend/src/express.d.ts
+++ b/bitcourse-backend/src/express.d.ts
@@ -1,0 +1,11 @@
+declare global {
+    namespace Express {
+        interface Request {
+            user?: {
+                role?: "admin" | "teacher" | "student";
+            };
+        }
+    }
+}
+
+export {};

--- a/bitcourse-backend/src/index.ts
+++ b/bitcourse-backend/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import subjectsRouter from "./routes/subjects";
 import cors from "cors";
+import securityMiddleware from "./middleware/security";
 
 const app = express();
 const PORT = 8000;
@@ -14,6 +15,8 @@ app.use(
 );
 
 app.use(express.json());
+
+app.use(securityMiddleware);
 
 app.get('/', (req, res) => {
     res.send('Hello, welcome to the Classroom API!');

--- a/bitcourse-backend/src/middleware/security.ts
+++ b/bitcourse-backend/src/middleware/security.ts
@@ -1,0 +1,90 @@
+import { slidingWindow } from "@arcjet/node";
+import type { ArcjetNodeRequest } from "@arcjet/node";
+import type { NextFunction, Request, Response } from "express";
+
+import aj from "../config/arcjet.js";
+
+const securityMiddleware = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    // If NODE_ENV is TEST, skip security middleware
+    if (process.env.NODE_ENV === "test") {
+        return next();
+    }
+
+    try {
+        const role: RateLimitRole = req.user?.role ?? "guest";
+
+        let limit: number;
+        let message: string;
+
+        switch (role) {
+            case "admin":
+                limit = 20;
+                message = "Admin request limit exceeded (20 per minute). Slow down!";
+                break;
+            case "teacher":
+            case "student":
+                limit = 10;
+                message = "User request limit exceeded (10 per minute). Please wait.";
+                break;
+            default:
+                limit = 5;
+                message =
+                    "Guest request limit exceeded (5 per minute). Please sign up for higher limits.";
+                break;
+        }
+
+        const client = aj.withRule(
+            slidingWindow({
+                mode: "LIVE",
+                interval: "1m",
+                max: limit,
+            })
+        );
+
+        const arcjetRequest: ArcjetNodeRequest = {
+            headers: req.headers,
+            method: req.method,
+            url: req.originalUrl ?? req.url,
+            socket: {
+                remoteAddress: req.socket.remoteAddress ?? req.ip ?? "0.0.0.0",
+            },
+        };
+
+        const decision = await client.protect(arcjetRequest);
+
+        if (decision.isDenied() && decision.reason.isBot()) {
+            return res.status(403).json({
+                error: "Forbidden",
+                message: "Automated requests are not allowed",
+            });
+        }
+
+        if (decision.isDenied() && decision.reason.isShield()) {
+            return res.status(403).json({
+                error: "Forbidden",
+                message: "Request blocked by security policy",
+            });
+        }
+
+        if (decision.isDenied() && decision.reason.isRateLimit()) {
+            return res.status(429).json({
+                error: "Too Many Requests",
+                message,
+            });
+        }
+
+        next();
+    } catch (error) {
+        console.error("Arcjet middleware error:", error);
+        res.status(500).json({
+            error: "Internal Server Error",
+            message: "Something went wrong with the security middleware.",
+        });
+    }
+};
+
+export default securityMiddleware;


### PR DESCRIPTION
## Summary
Implements Arcjet security middleware for the BitCourse backend with role-aware rate limiting, bot detection, and shield protection.

## Changes

### `config/arcjet.ts`
- Initializes Arcjet client with shield, bot detection, and a base sliding window rate limit
- Allows search engine and preview bots (e.g. Slack, Discord link previews)
- Throws on missing ARCJET_KEY at startup (skipped in test environment)

### `middleware/security.ts`
- Applies role-based rate limits using sliding window algorithm:
  - Admin: 20 requests/min
  - Teacher/Student: 10 requests/min
  - Guest (unauthenticated): 5 requests/min
- Dynamically overrides the base rate limit per request using `aj.withRule()`
- Returns structured error responses for bot, shield, and rate limit denials
- Skips middleware entirely in test environment
- Catches and logs unexpected Arcjet errors gracefully

### `types/express.d.ts`
- Extends Express `Request` interface to include `user.role` for RBAC-aware middleware

## Issues Resolved
Closes #25