### PR TITLE
feat: Isaac-ClassSubmission

### DIFF
--- a/bitcourse-backend/src/index.ts
+++ b/bitcourse-backend/src/index.ts
@@ -4,6 +4,8 @@ import('apminsight')
 
 import express from 'express';
 import subjectsRouter from "./routes/subjects.js";
+import usersRouter from "./routes/users.js";
+import classesRouter from "./routes/classes.js";
 import cors from "cors";
 import securityMiddleware from "./middleware/security.js";
 import {toNodeHandler} from "better-auth/node";
@@ -35,3 +37,6 @@ app.listen(PORT, () => {
 });
 
 app.use("/api/subjects", subjectsRouter);
+app.use("/api/users", usersRouter);
+app.use("/api/classes", classesRouter);
+

--- a/bitcourse-backend/src/routes/classes.ts
+++ b/bitcourse-backend/src/routes/classes.ts
@@ -1,0 +1,252 @@
+import express from "express";
+import { and, desc, eq, getTableColumns, ilike, or, sql } from "drizzle-orm";
+
+import { db } from "../db/index.js";
+import { classes, departments, enrollments, subjects, user } from "../db/schema/index.js";
+
+const router = express.Router();
+
+// Get all classes with optional search, subject, teacher filters, and pagination
+router.get("/", async (req, res) => {
+    try {
+        const { search, subject, teacher, page = 1, limit = 10 } = req.query;
+
+        const currentPage = Math.max(1, +page);
+        const limitPerPage = Math.max(1, +limit);
+        const offset = (currentPage - 1) * limitPerPage;
+
+        const filterConditions = [];
+
+        if (search) {
+            filterConditions.push(
+                or(
+                    ilike(classes.name, `%${search}%`),
+                    ilike(classes.inviteCode, `%${search}%`)
+                )
+            );
+        }
+
+        if (subject) {
+            filterConditions.push(ilike(subjects.name, `%${subject}%`));
+        }
+
+        if (teacher) {
+            filterConditions.push(ilike(user.name, `%${teacher}%`));
+        }
+
+        const whereClause =
+            filterConditions.length > 0 ? and(...filterConditions) : undefined;
+
+        const countResult = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(classes)
+            .leftJoin(subjects, eq(classes.subjectId, subjects.id))
+            .leftJoin(user, eq(classes.teacherId, user.id))
+            .where(whereClause);
+
+        const totalCount = countResult[0]?.count ?? 0;
+
+        const classesList = await db
+            .select({
+                ...getTableColumns(classes),
+                subject: {
+                    ...getTableColumns(subjects),
+                },
+                teacher: {
+                    ...getTableColumns(user),
+                },
+            })
+            .from(classes)
+            .leftJoin(subjects, eq(classes.subjectId, subjects.id))
+            .leftJoin(user, eq(classes.teacherId, user.id))
+            .where(whereClause)
+            .orderBy(desc(classes.createdAt))
+            .limit(limitPerPage)
+            .offset(offset);
+
+        res.status(200).json({
+            data: classesList,
+            pagination: {
+                page: currentPage,
+                limit: limitPerPage,
+                total: totalCount,
+                totalPages: Math.ceil(totalCount / limitPerPage),
+            },
+        });
+    } catch (error) {
+        console.error("GET /classes error:", error);
+        res.status(500).json({ error: "Failed to fetch classes" });
+    }
+});
+
+router.post("/", async (req, res) => {
+    try {
+        const {
+            name,
+            teacherId,
+            subjectId,
+            capacity,
+            description,
+            status,
+            bannerUrl,
+            bannerCldPubId,
+        } = req.body;
+
+        const [createdClass] = await db
+            .insert(classes)
+            .values({
+                subjectId,
+                inviteCode: Math.random().toString(36).substring(2, 9),
+                name,
+                teacherId,
+                bannerCldPubId,
+                bannerUrl,
+                capacity,
+                description,
+                schedules: [],
+                status,
+            })
+            .returning({ id: classes.id });
+
+        if (!createdClass) throw Error;
+
+        res.status(201).json({ data: createdClass });
+    } catch (error) {
+        console.error("POST /classes error:", error);
+        res.status(500).json({ error: "Failed to create class" });
+    }
+});
+
+// Get class details with counts
+router.get("/:id", async (req, res) => {
+    try {
+        const classId = Number(req.params.id);
+
+        if (!Number.isFinite(classId)) {
+            return res.status(400).json({ error: "Invalid class id" });
+        }
+
+        const [classDetails] = await db
+            .select({
+                ...getTableColumns(classes),
+                subject: {
+                    ...getTableColumns(subjects),
+                },
+                department: {
+                    ...getTableColumns(departments),
+                },
+                teacher: {
+                    ...getTableColumns(user),
+                },
+            })
+            .from(classes)
+            .leftJoin(subjects, eq(classes.subjectId, subjects.id))
+            .leftJoin(departments, eq(subjects.departmentId, departments.id))
+            .leftJoin(user, eq(classes.teacherId, user.id))
+            .where(eq(classes.id, classId));
+
+        if (!classDetails) {
+            return res.status(404).json({ error: "Class not found" });
+        }
+
+        res.status(200).json({ data: classDetails });
+    } catch (error) {
+        console.error("GET /classes/:id error:", error);
+        res.status(500).json({ error: "Failed to fetch class details" });
+    }
+});
+
+// List users in a class by role with pagination
+router.get("/:id/users", async (req, res) => {
+    try {
+        const classId = Number(req.params.id);
+        const { role, page = 1, limit = 10 } = req.query;
+
+        if (!Number.isFinite(classId)) {
+            return res.status(400).json({ error: "Invalid class id" });
+        }
+
+        if (role !== "teacher" && role !== "student") {
+            return res.status(400).json({ error: "Invalid role" });
+        }
+
+        const currentPage = Math.max(1, +page);
+        const limitPerPage = Math.max(1, +limit);
+        const offset = (currentPage - 1) * limitPerPage;
+
+        const baseSelect = {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            emailVerified: user.emailVerified,
+            image: user.image,
+            role: user.role,
+            imageCldPubId: user.imageCldPubId,
+            createdAt: user.createdAt,
+            updatedAt: user.updatedAt,
+        };
+
+        const groupByFields = [
+            user.id,
+            user.name,
+            user.email,
+            user.emailVerified,
+            user.image,
+            user.role,
+            user.imageCldPubId,
+            user.createdAt,
+            user.updatedAt,
+        ];
+
+        const countResult =
+            role === "teacher"
+                ? await db
+                    .select({ count: sql<number>`count(distinct ${user.id})` })
+                    .from(user)
+                    .leftJoin(classes, eq(user.id, classes.teacherId))
+                    .where(and(eq(user.role, role), eq(classes.id, classId)))
+                : await db
+                    .select({ count: sql<number>`count(distinct ${user.id})` })
+                    .from(user)
+                    .leftJoin(enrollments, eq(user.id, enrollments.studentId))
+                    .where(and(eq(user.role, role), eq(enrollments.classId, classId)));
+
+        const totalCount = countResult[0]?.count ?? 0;
+
+        const usersList =
+            role === "teacher"
+                ? await db
+                    .select(baseSelect)
+                    .from(user)
+                    .leftJoin(classes, eq(user.id, classes.teacherId))
+                    .where(and(eq(user.role, role), eq(classes.id, classId)))
+                    .groupBy(...groupByFields)
+                    .orderBy(desc(user.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset)
+                : await db
+                    .select(baseSelect)
+                    .from(user)
+                    .leftJoin(enrollments, eq(user.id, enrollments.studentId))
+                    .where(and(eq(user.role, role), eq(enrollments.classId, classId)))
+                    .groupBy(...groupByFields)
+                    .orderBy(desc(user.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset);
+
+        res.status(200).json({
+            data: usersList,
+            pagination: {
+                page: currentPage,
+                limit: limitPerPage,
+                total: totalCount,
+                totalPages: Math.ceil(totalCount / limitPerPage),
+            },
+        });
+    } catch (error) {
+        console.error("GET /classes/:id/users error:", error);
+        res.status(500).json({ error: "Failed to fetch class users" });
+    }
+});
+
+export default router;

--- a/bitcourse-backend/src/routes/users.ts
+++ b/bitcourse-backend/src/routes/users.ts
@@ -1,0 +1,314 @@
+import express from "express";
+import { and, desc, eq, ilike, or, sql, getTableColumns } from "drizzle-orm";
+
+import { db } from "../db/index.js";
+import { classes, departments, enrollments, subjects, user } from "../db/schema/index.js";
+
+const router = express.Router();
+
+// Get all users with optional search, role filter, and pagination
+router.get("/", async (req, res) => {
+    try {
+        const { search, role, page = 1, limit = 10 } = req.query;
+
+        const currentPage = Math.max(1, +page);
+        const limitPerPage = Math.max(1, +limit);
+        const offset = (currentPage - 1) * limitPerPage;
+
+        const filterConditions = [];
+
+        if (search) {
+            filterConditions.push(
+                or(ilike(user.name, `%${search}%`), ilike(user.email, `%${search}%`))
+            );
+        }
+
+        if (role) {
+            filterConditions.push(eq(user.role, role as UserRoles));
+        }
+
+        const whereClause =
+            filterConditions.length > 0 ? and(...filterConditions) : undefined;
+
+        const countResult = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(user)
+            .where(whereClause);
+
+        const totalCount = countResult[0]?.count ?? 0;
+
+        const usersList = await db
+            .select()
+            .from(user)
+            .where(whereClause)
+            .orderBy(desc(user.createdAt))
+            .limit(limitPerPage)
+            .offset(offset);
+
+        res.status(200).json({
+            data: usersList,
+            pagination: {
+                page: currentPage,
+                limit: limitPerPage,
+                total: totalCount,
+                totalPages: Math.ceil(totalCount / limitPerPage),
+            },
+        });
+    } catch (error) {
+        console.error("GET /users error:", error);
+        res.status(500).json({ error: "Failed to fetch users" });
+    }
+});
+
+// Get user details with role-specific data
+router.get("/:id", async (req, res) => {
+    try {
+        const userId = req.params.id;
+
+        const [userRecord] = await db
+            .select()
+            .from(user)
+            .where(eq(user.id, userId));
+
+        if (!userRecord) {
+            return res.status(404).json({ error: "User not found" });
+        }
+
+        res.status(200).json({ data: userRecord });
+    } catch (error) {
+        console.error("GET /users/:id error:", error);
+        res.status(500).json({ error: "Failed to fetch user" });
+    }
+});
+
+// List departments associated with a user
+router.get("/:id/departments", async (req, res) => {
+    try {
+        const userId = req.params.id;
+        const { page = 1, limit = 10 } = req.query;
+
+        const [userRecord] = await db
+            .select({ id: user.id, role: user.role })
+            .from(user)
+            .where(eq(user.id, userId));
+
+        if (!userRecord) {
+            return res.status(404).json({ error: "User not found" });
+        }
+
+        if (userRecord.role !== "teacher" && userRecord.role !== "student") {
+            return res.status(200).json({
+                data: [],
+                pagination: {
+                    page: 1,
+                    limit: 0,
+                    total: 0,
+                    totalPages: 0,
+                },
+            });
+        }
+
+        const currentPage = Math.max(1, +page);
+        const limitPerPage = Math.max(1, +limit);
+        const offset = (currentPage - 1) * limitPerPage;
+
+        const countResult =
+            userRecord.role === "teacher"
+                ? await db
+                    .select({ count: sql<number>`count(distinct ${departments.id})` })
+                    .from(departments)
+                    .leftJoin(subjects, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .where(eq(classes.teacherId, userId))
+                : await db
+                    .select({ count: sql<number>`count(distinct ${departments.id})` })
+                    .from(departments)
+                    .leftJoin(subjects, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .leftJoin(enrollments, eq(enrollments.classId, classes.id))
+                    .where(eq(enrollments.studentId, userId));
+
+        const totalCount = countResult[0]?.count ?? 0;
+
+        const departmentsList =
+            userRecord.role === "teacher"
+                ? await db
+                    .select({
+                        ...getTableColumns(departments),
+                    })
+                    .from(departments)
+                    .leftJoin(subjects, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .where(eq(classes.teacherId, userId))
+                    .groupBy(
+                        departments.id,
+                        departments.code,
+                        departments.name,
+                        departments.description,
+                        departments.createdAt,
+                        departments.updatedAt
+                    )
+                    .orderBy(desc(departments.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset)
+                : await db
+                    .select({
+                        ...getTableColumns(departments),
+                    })
+                    .from(departments)
+                    .leftJoin(subjects, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .leftJoin(enrollments, eq(enrollments.classId, classes.id))
+                    .where(eq(enrollments.studentId, userId))
+                    .groupBy(
+                        departments.id,
+                        departments.code,
+                        departments.name,
+                        departments.description,
+                        departments.createdAt,
+                        departments.updatedAt
+                    )
+                    .orderBy(desc(departments.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset);
+
+        res.status(200).json({
+            data: departmentsList,
+            pagination: {
+                page: currentPage,
+                limit: limitPerPage,
+                total: totalCount,
+                totalPages: Math.ceil(totalCount / limitPerPage),
+            },
+        });
+    } catch (error) {
+        console.error("GET /users/:id/departments error:", error);
+        res.status(500).json({ error: "Failed to fetch user departments" });
+    }
+});
+
+// List subjects associated with a user
+router.get("/:id/subjects", async (req, res) => {
+    try {
+        const userId = req.params.id;
+        const { page = 1, limit = 10 } = req.query;
+
+        const [userRecord] = await db
+            .select({ id: user.id, role: user.role })
+            .from(user)
+            .where(eq(user.id, userId));
+
+        if (!userRecord) {
+            return res.status(404).json({ error: "User not found" });
+        }
+
+        if (userRecord.role !== "teacher" && userRecord.role !== "student") {
+            return res.status(200).json({
+                data: [],
+                pagination: {
+                    page: 1,
+                    limit: 0,
+                    total: 0,
+                    totalPages: 0,
+                },
+            });
+        }
+
+        const currentPage = Math.max(1, +page);
+        const limitPerPage = Math.max(1, +limit);
+        const offset = (currentPage - 1) * limitPerPage;
+
+        const countResult =
+            userRecord.role === "teacher"
+                ? await db
+                    .select({ count: sql<number>`count(distinct ${subjects.id})` })
+                    .from(subjects)
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .where(eq(classes.teacherId, userId))
+                : await db
+                    .select({ count: sql<number>`count(distinct ${subjects.id})` })
+                    .from(subjects)
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .leftJoin(enrollments, eq(enrollments.classId, classes.id))
+                    .where(eq(enrollments.studentId, userId));
+
+        const totalCount = countResult[0]?.count ?? 0;
+
+        const subjectsList =
+            userRecord.role === "teacher"
+                ? await db
+                    .select({
+                        ...getTableColumns(subjects),
+                        department: {
+                            ...getTableColumns(departments),
+                        },
+                    })
+                    .from(subjects)
+                    .leftJoin(departments, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .where(eq(classes.teacherId, userId))
+                    .groupBy(
+                        subjects.id,
+                        subjects.departmentId,
+                        subjects.name,
+                        subjects.code,
+                        subjects.description,
+                        subjects.createdAt,
+                        subjects.updatedAt,
+                        departments.id,
+                        departments.code,
+                        departments.name,
+                        departments.description,
+                        departments.createdAt,
+                        departments.updatedAt
+                    )
+                    .orderBy(desc(subjects.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset)
+                : await db
+                    .select({
+                        ...getTableColumns(subjects),
+                        department: {
+                            ...getTableColumns(departments),
+                        },
+                    })
+                    .from(subjects)
+                    .leftJoin(departments, eq(subjects.departmentId, departments.id))
+                    .leftJoin(classes, eq(classes.subjectId, subjects.id))
+                    .leftJoin(enrollments, eq(enrollments.classId, classes.id))
+                    .where(eq(enrollments.studentId, userId))
+                    .groupBy(
+                        subjects.id,
+                        subjects.departmentId,
+                        subjects.name,
+                        subjects.code,
+                        subjects.description,
+                        subjects.createdAt,
+                        subjects.updatedAt,
+                        departments.id,
+                        departments.code,
+                        departments.name,
+                        departments.description,
+                        departments.createdAt,
+                        departments.updatedAt
+                    )
+                    .orderBy(desc(subjects.createdAt))
+                    .limit(limitPerPage)
+                    .offset(offset);
+
+        res.status(200).json({
+            data: subjectsList,
+            pagination: {
+                page: currentPage,
+                limit: limitPerPage,
+                total: totalCount,
+                totalPages: Math.ceil(totalCount / limitPerPage),
+            },
+        });
+    } catch (error) {
+        console.error("GET /users/:id/subjects error:", error);
+        res.status(500).json({ error: "Failed to fetch user subjects" });
+    }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
Adds REST API routes for classes and users, enabling the frontend to query, filter, and paginate both resources with role-aware data access.

## Changes

### `src/routes/classes.ts`
- `GET /classes` — list all classes with optional search (name/invite code), subject filter, teacher filter, and pagination. Joins subjects and user tables for full class details
- `POST /classes` — create a new class with auto-generated invite code
- `GET /classes/:id` — get full class details including subject, department, and teacher
- `GET /classes/:id/users` — list users in a class filtered by role (teacher/student) with pagination

### `src/routes/users.ts`
- `GET /users` — list all users with optional search (name/email), role filter, and pagination
- `GET /users/:id` — get individual user details
- `GET /users/:id/departments` — list departments associated with a user, role-aware (teacher via classes, student via enrollments)
- `GET /users/:id/subjects` — list subjects associated with a user, role-aware with department join

### `src/index.ts`
- Registered `/api/classes` and `/api/users` routes

## Issues Resolved
Closes #42
Closes #11
Closes #9